### PR TITLE
Upgrade GatewayD to v0.9.8 and Refactor Configuration Management

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: gatewayd
 description: Cloud-native database gateway and framework for building data-driven applications, Like API gateways, for databases.
 type: application
 version: 0.1.0
-appVersion: v0.9.7
+appVersion: v0.9.8
 home: https://www.gatewayd.io
 icon: https://github.com/gatewayd-io/docs/blob/main/assets/gatewayd-logotype-light.png
 sources:

--- a/files/gatewayd.yaml
+++ b/files/gatewayd.yaml
@@ -2,7 +2,7 @@
 loggers:
   default:
     output: ["console"] # "stdout", "stderr", "syslog", "rsyslog" and "file"
-    level: "debug" # panic, fatal, error, warn, info (default), debug, trace
+    level: "info" # panic, fatal, error, warn, info (default), debug, trace
     noColor: False
     timeFormat: "unix" # unixms, unixmicro and unixnano
     consoleTimeFormat: "RFC3339" # Go time format string

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "gatewayd.fullname" . }}
-  labels:
-    app: gatewayd
-data:
-  GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS: {{ .Values.gatewayd.clients.default.writes.address }}
-  GATEWAYD_LOGGERS_DEFAULT_LEVEL: {{ .Values.gatewayd.loggers.default.level }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -46,9 +46,13 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ include "gatewayd.fullname" . }}
+          {{- if .Values.extraEnvVars}}
+          env:
+            {{- range $key, $value := .Values.extraEnvVars }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end}}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,12 +1,3 @@
-gatewayd:
-  clients:
-    default:
-      writes:
-        address: "psql-postgresql:5432"
-  loggers:
-    default:
-      # For production, use info
-      level: debug
 replicaCount: 1
 
 image:
@@ -96,8 +87,18 @@ podDisruptionBudget:
   minAvailable: 1
   # maxUnavailable: 1
 
+# If gatewaydPluginsConfig is disabled, GatewayD will use the default plugin configuration.
+# The default config can be found here: https://github.com/gatewayd-io/gatewayd/blob/main/gatewayd_plugins.yaml
 gatewaydPluginsConfig:
   enabled: true
 
+# If gatewaydConfig is disabled, GatewayD will use the default configuration.
+# The default config can be found here: https://github.com/gatewayd-io/gatewayd/blob/main/gatewayd.yaml
 gatewaydConfig: 
   enabled: true
+
+# Configuration can be overridden using environment variables. 
+# For more details, visit: https://docs.gatewayd.io/using-gatewayd/configuration/#environment-variables
+# extraEnvVars:
+#   GATEWAYD_CLIENTS_DEFAULT_WRITES_ADDRESS: psql-postgresql:5432
+#   GATEWAYD_LOGGERS_DEFAULT_LEVEL: debug # For production, use info


### PR DESCRIPTION
This PR introduces the following updates and improvements:

- Upgrade GatewayD version: Updated the app version from `v0.9.7` to `v0.9.8` in Chart.yaml.
- Logging Configuration: Changed the default logging level from `debug` to `info` in gatewayd.yaml for production readiness.
- Refactor ConfigMap: Removed the ConfigMap template and replaced it with environment variables defined via extraEnvVars in deployment.yaml, streamlining the configuration process.
  - Added support for overriding configurations using environment variables in values.yaml, providing better flexibility for GatewayD’s configuration.
  - Removed unused gatewayd client and logger configuration from values.yaml.

- Bugfix: Fixed an indentation issue in serviceaccount.yaml related to `automountServiceAccountToken`.